### PR TITLE
Fix failed nodes report

### DIFF
--- a/lib/puppet/catalog-diff/compilecatalog.rb
+++ b/lib/puppet/catalog-diff/compilecatalog.rb
@@ -104,7 +104,7 @@ module Puppet::CatalogDiff
               else
                 Puppet.runtime[:http].get(uri, headers: headers, options: { ssl_context: ssl_context })
               end
-        raise "HTTP request to Puppetserver #{server} failed with: HTTP #{ret.code} - #{ret.reason}" unless ret.success?
+        raise "HTTP request to Puppetserver #{server} failed with: HTTP #{ret.code} - #{ret.body}" unless ret.success?
       rescue Exception => e
         raise "Failed to retrieve catalog for #{node_name} from #{server} in environment #{environment}: #{e.message}"
       end

--- a/lib/puppet/face/catalog/diff.rb
+++ b/lib/puppet/face/catalog/diff.rb
@@ -208,7 +208,7 @@ Puppet::Face.define(:catalog, '0.0.1') do
         # User passed us two hostnames
         old_catalogs = Dir.mktmpdir("#{catalog1.tr('/', '_')}-")
         new_catalogs = Dir.mktmpdir("#{catalog2.tr('/', '_')}-")
-        pull_output = Puppet::Face[:catalog, '0.0.1'].pull(
+        @pull_output = Puppet::Face[:catalog, '0.0.1'].pull(
           old_catalogs, new_catalogs,
           options[:fact_search],
           old_server: catalog1, new_server: catalog2,
@@ -232,7 +232,7 @@ Puppet::Face.define(:catalog, '0.0.1') do
         nodes = diff_output
         FileUtils.rm_rf(old_catalogs)
         FileUtils.rm_rf(new_catalogs)
-        nodes[:pull_output] = pull_output
+        nodes[:pull_output] = @pull_output
         return nodes
       end
       raise 'No nodes were matched' if nodes.size.zero?
@@ -253,6 +253,7 @@ Puppet::Face.define(:catalog, '0.0.1') do
       nodes[:total_nodes]        = total_nodes
       nodes[:date]               = Time.new.iso8601
       nodes[:all_changed_nodes]  = with_changes.keys
+      nodes[:pull_output]        = @pull_output unless @pull_output.nil?
 
       if options[:output_report]
         Puppet.notice("Writing report to disk: #{options[:output_report]}")


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

Fix visibility on failed nodes in the output report for the Catalog Diff Viewer

PR 50 introduced a bug where the pull_output is not being added to the nodes hash when the report is written.
Adding pull_output back to the nodes hash to be written to the json report.
This allows the Catalog Diff Viewer to see failed nodes in the report.

Changing the compile catalog to print body instead of reason when a compile fails as it provides the log entry with reason why compile failed for the node.

#### This Pull Request (PR) fixes the following issues
Fixes #92 

