### PR TITLE
Allow trusted facts to be derived from node name

### DIFF
--- a/lib/puppet/face/catalog/diff.rb
+++ b/lib/puppet/face/catalog/diff.rb
@@ -123,6 +123,10 @@ Puppet::Face.define(:catalog, '0.0.1') do
       default_to { puppetdb_url }
     end
 
+    option '--derive_trusted_facts' do
+      summary 'Derive trusted facts from node name when using certless API. When disabled, Puppet will use trusted facts from PuppetDB.'
+    end
+
     description <<-EOT
       Prints the differences between catalogs compiled by different puppet master to help
       during migrating to a new Puppet version.
@@ -226,7 +230,8 @@ Puppet::Face.define(:catalog, '0.0.1') do
           old_puppetserver_tls_key: options[:old_puppetserver_tls_key],
           old_puppetserver_tls_ca: options[:old_puppetserver_tls_ca],
           new_puppetdb: options[:new_puppetdb],
-          node_list: options[:node_list]
+          node_list: options[:node_list],
+          derive_trusted_facts: options[:derive_trusted_facts]
         )
         diff_output = Puppet::Face[:catalog, '0.0.1'].diff(old_catalogs, new_catalogs, options)
         nodes = diff_output

--- a/lib/puppet/face/catalog/pull.rb
+++ b/lib/puppet/face/catalog/pull.rb
@@ -93,6 +93,10 @@ Puppet::Face.define(:catalog, '0.0.1') do
       summary 'A manual list of nodes to run catalog diffs against'
     end
 
+    option '--derive_trusted_facts' do
+      summary 'Derive trusted facts from node name when using certless API. When disabled, Puppet will use trusted facts from PuppetDB.'
+    end
+
     description <<-EOT
       This action is used to seed a series of catalogs from two servers
     EOT
@@ -147,14 +151,16 @@ Puppet::Face.define(:catalog, '0.0.1') do
                   puppetdb_tls_ca: options[:old_puppetdb_tls_ca],
                   puppetserver_tls_cert: options[:old_puppetserver_tls_cert],
                   puppetserver_tls_key: options[:old_puppetserver_tls_key],
-                  puppetserver_tls_ca: options[:old_puppetserver_tls_ca]
+                  puppetserver_tls_ca: options[:old_puppetserver_tls_ca],
+                  derive_trusted_facts: options[:derive_trusted_facts]
                 )
                 new_server = Puppet::Face[:catalog, '0.0.1'].seed(
                   catalog2, node_name,
                   master_server: options[:new_server],
                   certless: options[:certless],
                   catalog_from_puppetdb: options[:new_catalog_from_puppetdb],
-                  puppetdb: options[:new_puppetdb]
+                  puppetdb: options[:new_puppetdb],
+                  derive_trusted_facts: options[:derive_trusted_facts]
                 )
               else
                 new_server = Puppet::Face[:catalog, '0.0.1'].seed(
@@ -162,7 +168,8 @@ Puppet::Face.define(:catalog, '0.0.1') do
                   master_server: options[:new_server],
                   certless: options[:certless],
                   catalog_from_puppetdb: options[:new_catalog_from_puppetdb],
-                  puppetdb: options[:new_puppetdb]
+                  puppetdb: options[:new_puppetdb],
+                  derive_trusted_facts: options[:derive_trusted_facts]
                 )
                 old_server = Puppet::Face[:catalog, '0.0.1'].seed(
                   catalog1, node_name,
@@ -175,7 +182,8 @@ Puppet::Face.define(:catalog, '0.0.1') do
                   puppetdb_tls_ca: options[:old_puppetdb_tls_ca],
                   puppetserver_tls_cert: options[:old_puppetserver_tls_cert],
                   puppetserver_tls_key: options[:old_puppetserver_tls_key],
-                  puppetserver_tls_ca: options[:old_puppetserver_tls_ca]
+                  puppetserver_tls_ca: options[:old_puppetserver_tls_ca],
+                  derive_trusted_facts: options[:derive_trusted_facts]
                 )
               end
               mutex.synchronize { compiled_nodes + old_server[:compiled_nodes] }

--- a/lib/puppet/face/catalog/seed.rb
+++ b/lib/puppet/face/catalog/seed.rb
@@ -58,6 +58,10 @@ Puppet::Face.define(:catalog, '0.0.1') do
       default_to { localcacert }
     end
 
+    option '--derive_trusted_facts' do
+      summary 'Derive trusted facts from node name when using certless API. When disabled, Puppet will use trusted facts from PuppetDB.'
+    end
+
     description <<-EOT
       This action is used to seed a series of catalogs to then be compared with diff
     EOT
@@ -109,7 +113,8 @@ Puppet::Face.define(:catalog, '0.0.1') do
                 options[:puppetdb_tls_ca],
                 options[:puppetserver_tls_cert],
                 options[:puppetserver_tls_key],
-                options[:puppetserver_tls_ca]
+                options[:puppetserver_tls_ca],
+                options[:derive_trusted_facts]
               )
               mutex.synchronize { compiled_nodes << node_name }
             rescue Exception => e


### PR DESCRIPTION
#### Allow trusted facts to be derived from node name

When using the certless API, Puppet will use trusted facts from PuppetDB unless provided in the request. If the PuppetDB facts were uploaded by the catalog_diff host, the trusted facts in PuppetDB will be for the catalog_diff host rather than the node being evaluated. This allows the trusted facts to be derived from the node name instead of using values from PuppetDB.

Perhaps there is a way to have Puppet store the trusted facts as presented in the facts file being uploaded, but from what I can tell the facts API always replaces trusted facts with data derived from the client cert.