### PR TITLE
Fix for resources that have a parameter named `type`

### DIFF
--- a/lib/puppet/face/catalog/diff.rb
+++ b/lib/puppet/face/catalog/diff.rb
@@ -283,7 +283,7 @@ Puppet::Face.define(:catalog, '0.0.1') do
             value.map do |resource_id, resource|
               next if resource.nil?
 
-              if resource.is_a?(Hash) && resource.key?(:type)
+              if resource.is_a?(Hash) && resource.key?(:type) && !%i[params_in_old params_in_new].include?(header)
                 # If we find an actual resource print it out
                 format.resource_reference(header, resource_id, resource)
               elsif resource.is_a?(Array)


### PR DESCRIPTION
According to
https://www.puppet.com/docs/puppet/7/lang_reserved.html#parameter-names `type` is perfectly acceptable as the name of a class or defined type parameter.

For example
https://github.com/voxpupuli/puppet-rsyslog/blob/3e6a94cd92e59c8d4a289b9e1fbb30e227bb48e6/manifests/component/template.pp#L5

Unfortunately, the existing code decided it was looking at a resource, (and not a resource's changed parameters), by looking for a hash key of `type`.  This was tripping it up when formatting the report.

Specifically, the code would explode here
https://github.com/voxpupuli/puppet-catalog_diff/blob/a60fd2d526056feb31122b44823a35e8215f4305/lib/puppet/catalog-diff/formater.rb#L54

with
```
Error: undefined method `sort_by' for nil:NilClass`
```

as the method isn't being fed a resource and the `:parameters` key is missing.

In this commit, we check the value of `header` to make sure we're not calling `format.resource_reference` with something that isn't a resource, and instead fall through to the correct `Format hash diffs` code in the `else`.
(https://github.com/voxpupuli/puppet-catalog_diff/blob/a60fd2d526056feb31122b44823a35e8215f4305/lib/puppet/face/catalog/diff.rb#L298)